### PR TITLE
fix the mismatch of sizes of vectors in kinematics simulation mode.

### DIFF
--- a/components/code/mtsPID.cpp
+++ b/components/code/mtsPID.cpp
@@ -851,7 +851,7 @@ void mtsPID::GetIOData(const bool computeVelocity)
         mPositionMeasure.Position().Assign(mStateJointCommand.Position(), mNumberOfActiveJoints);
         mPositionMeasure.SetTimestamp(StateTable.GetTic());
         // measured effort
-        mEffortMeasure.Assign(mEffortUserCommand.ForceTorque());
+        mEffortMeasure.Assign(mEffortUserCommand.ForceTorque(), mNumberOfActiveJoints);
     } else {
         Robot.GetFeedbackPosition(mPositionMeasure);
         Robot.GetFeedbackEffort(mEffortMeasure);


### PR DESCRIPTION
The size of mEffortMeasure is larger than the size of mEffortUserCommand. In order to avoid exceptions being thrown, we need to provide second argument mNumberOfActiveJoints to Assign function. See https://github.com/jhu-saw/sawControllers/pull/1