### PR TITLE
Refactoring of the simulation mode using CISST prmSimulationType

### DIFF
--- a/core/components/code/mtsPID.cpp
+++ b/core/components/code/mtsPID.cpp
@@ -142,7 +142,7 @@ void mtsPID::enforce_position_limits(const bool & enforce)
             m_enforce_position_limits = enforce;
             return;
         } else {
-            if (!m_simulated) {
+            if (!(GetSimulationMode() == prmSimulationType::SimulationType::KINEMATIC)) {
                 mInterface->SendWarning(this->GetName() + ": unable to enforce position limits since the limits are not set properly");
             }
             CMN_LOG_CLASS_INIT_VERBOSE << this->GetName() << " enforce_position_limits: using configuration " << m_configuration_js << std::endl;
@@ -318,7 +318,7 @@ void mtsPID::Configure(const std::string & filename)
 void mtsPID::Startup(void)
 {
     // get joint type from IO and check against values from PID config file
-    if (!m_simulated) {
+    if (!(GetSimulationMode() == prmSimulationType::SimulationType::KINEMATIC)) {
         mtsExecutionResult result;
         prmConfigurationJoint io_configuration_js;
         result = IO.configuration_js(io_configuration_js);
@@ -630,7 +630,7 @@ void mtsPID::Run(void)
     }
 
     // for simulated mode
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::SimulationType::KINEMATIC)) {
         m_measured_js.SetValid(true);
         m_measured_js.Position().Assign(m_setpoint_js.Position());
         m_measured_js.SetTimestamp(StateTable.GetTic());
@@ -645,10 +645,11 @@ void mtsPID::Cleanup(void)
     servo_jf_local(m_setpoint_js.Effort());
 }
 
-
-void mtsPID::SetSimulated(void)
+void mtsPID::SetSimulationMode(const prmSimulationType::SimulationType &mode)
 {
-    m_simulated = true;
+    // forward to base class
+    prmSimulationType::SetSimulationMode(mode);
+
     // in simulation mode, we don't need IO
     RemoveInterfaceRequired("RobotJointTorqueInterface");
 }
@@ -829,7 +830,7 @@ void mtsPID::get_IO_data(void)
     // get data from IO if not in simulated mode.  When is simulation
     // mode, position come from the user/client and is found in
     // m_setpoint_js
-    if (m_simulated) {
+    if ((GetSimulationMode() == prmSimulationType::SimulationType::KINEMATIC)) {
         // check that position is not too old
         if ((StateTable.GetTic() - m_command_time) > 20.0 * cmn_ms) {
             m_measured_js.Velocity().Zeros();
@@ -894,7 +895,7 @@ void mtsPID::get_IO_data(void)
 
 void mtsPID::servo_jf_local(const vctDoubleVec & effort)
 {
-    if (!m_simulated) {
+    if (!(GetSimulationMode() == prmSimulationType::SimulationType::KINEMATIC)) {
         m_pid_setpoint_jf.ForceTorque().Assign(effort);
         IO.servo_jf(m_pid_setpoint_jf);
     }

--- a/core/components/include/sawControllers/mtsPID.h
+++ b/core/components/include/sawControllers/mtsPID.h
@@ -34,13 +34,15 @@ http://www.cisst.org/cisst/license.txt.
 #include <cisstParameterTypes/prmStateJoint.h>
 #include <cisstParameterTypes/prmConfigurationJoint.h>
 
+#include <cisstParameterTypes/prmSimulationType.h>
+
 #include <sawControllers/sawControllersRevision.h>
 #include <sawControllers/mtsPIDConfiguration.h>
 
 //! Always include last
 #include <sawControllers/sawControllersExport.h>
 
-class CISST_EXPORT mtsPID: public mtsTaskPeriodic
+class CISST_EXPORT mtsPID: public mtsTaskPeriodic, prmSimulationType
 {
     CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_ALLOW_DEFAULT);
 
@@ -111,9 +113,6 @@ protected:
     bool m_measured_setpoint_check;
     vctBoolVec m_previous_measured_setpoint_error, m_measured_setpoint_error;
 
-    // Flag to determine if this is connected to actual IO/hardware or
-    // simulated
-    bool m_simulated = false;
     double m_command_time, m_previous_command_time;
 
     //! Configuration state table
@@ -206,7 +205,8 @@ public:
     void Run(void);
     void Cleanup(void);
 
-    void SetSimulated(void);
+    // Override from prmSimulationType for handling simulation mode in derived classes
+    virtual void SetSimulationMode(const prmSimulationType::SimulationType& mode) override;
 
 protected:
 


### PR DESCRIPTION
Hi @adeguet1 
This pull request follows https://github.com/jhu-dvrk/sawIntuitiveResearchKit/pull/244.

The affected class is just `mtsPID`, the behaviour is unchanged. The simulation mode is now derived and stored via the base class `prmSimulationType`.